### PR TITLE
Better handling of injector failures

### DIFF
--- a/injector_helper.c
+++ b/injector_helper.c
@@ -668,12 +668,12 @@ static int start_taking_requests(proxy *p)
     return 0;
 }
 
-static void on_injectors_found(proxy *proxy, const byte *peers, uint num_peers)
+static void on_injectors_found(proxy *p, const byte *peers, uint num_peers)
 {
     for (uint i = 0; i < num_peers; ++i) {
-        endpoint ep = *((endpoint *)peers + i * sizeof(endpoint));
+        endpoint ep = ((endpoint *)peers)[i];
         ep.port = ntohs(ep.port);
-        proxy_add_injector(proxy, ep);
+        proxy_add_injector(p, ep);
     }
 }
 

--- a/network.h
+++ b/network.h
@@ -11,6 +11,7 @@
 
 
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
+#define MAX(X, Y) (((X) < (Y)) ? (Y) : (X))
 #define lenof(x) (sizeof(x)/sizeof(x[0]))
 #define alloc(type) calloc(1, sizeof(type))
 


### PR DESCRIPTION
* Test injectors before they are used.
   Every time a new injector is found by the DHT, the injector helper tries to fetch bbc.com,
   only if it's successful it is considered for use with requests from clients.
   (TODO: these test requests should go directly to the injector, but injector doesn't recognize them yet).
* Retry with different injector on failure.
   If a request to a particular injector fails, the injector helper tries the same request with
   another injector. Up to MAX_INJECTORS_TO_TRY (=3) injectors are tried before the injector
   helper responds with failure.
* Assign ranks to injectors.
  From time to time the injector helper receives UTP_ECONNRESET or UTP_ETIMEOUT errors even
  though the injector still seem to work properly for next requests. To avoid situations where the
  injectors are rejected for further consideration a ranking heuristic is applied.

Ranking algorithm: once an injector is found and tested its rank is set to 1. Every time the injector responds to a request (doesn't have to be HTTP OK, but does have to respond) its rank is incremented but clamped to max MAX_RANK (=5). Injector is only considered for requests by clients if its rank is > 0. Every time an injector fails to respond its rank is decremented. Ranks can have negative values (clamped with MIN_RANK (= -5)) where lower negative rank means bigger timeout before it is probed (with the bbc.com web page) again.

resolves #5 
