### PR TITLE
Don't test with 64 concurrent jobs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,14 +3,14 @@ set -e
 
 echo "Building libutp..."
 cd libutp
-make
+make -j $(nproc)
 cd ..
 
 echo "Building Libevent..."
 cd Libevent
 if [ ! -f configure ]; then ./autogen.sh; fi
 if [ ! -f Makefile ]; then ./configure; fi
-make
+make -j $(nproc)
 cd ..
 
 echo "Building libbtdht..."
@@ -27,7 +27,7 @@ echo "Building libsodium..."
 cd libsodium
 if [ ! -f configure ]; then ./autogen.sh; fi
 if [ ! -f Makefile ]; then ./configure; fi
-make
+make -j $(nproc)
 cd ..
 
 FLAGS="-g -O0 -Werror -Wall -Wextra -Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-variable -Wno-error=shadow -Wfatal-errors \


### PR DESCRIPTION
It seems that the python http server can't handle that many concurrent requests coming from the injector and causes the requests to fail. Assuming this is true, the easiest solution is to decrease the number of concurrent requests.