### PR TITLE
Close uTP connection if origin down

### DIFF
--- a/utp_bufferevent.c
+++ b/utp_bufferevent.c
@@ -183,6 +183,8 @@ void ubev_event_cb(struct bufferevent *bev, short events, void *ctx)
     }
     if (events & BEV_EVENT_EOF) {
         bufferevent_disable(u->bev, EV_READ);
+        utp_close(u->utp);
+        u->utp = NULL;
     }
     ubev_bev_check_flush(u);
 }


### PR DESCRIPTION
When the injector received an EOF from origin (if it was down) it did not
clost the uTP connection it had with the injector_helper. Thus injector_helper
kept waiting for a HTTP response until it timed out after 50 seconds. This
commit closes the uTP connection and upates test to make sure the client
is notified quickly about the origin being down.