### PR TITLE
[WIP] add script to build using docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:focal
+
+RUN apt-get -y update && \
+	apt-get -y upgrade && \
+	apt-get -y install build-essential clang git
+
+# Are other dependencies required?  This is as far as I got in the alloted time.
+#RUN apt-get -y install random-build-tool libtransitive-dependency-dev
+
+WORKDIR /
+
+# obtain the source code from GitHub
+RUN git clone --recurse-submodules https://github.com/clostra/newnode.git
+# or, move the files in `docker/` to the top-level directory, remove that last
+# line, and uncomment the next one to use your local source code
+#COPY . /newnode
+
+WORKDIR /newnode
+RUN ./build.sh

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script attempts to build a docker image (based on Ubuntu 20.04) that
+# checks out the NewCode code from GitHub and builds it following the
+# instructions in the README.
+
+set -euo pipefail
+
+script="${BASH_SOURCE[0]}"
+dir=$(dirname "$script")
+
+docker build -t newnode "$dir"


### PR DESCRIPTION
This patch adds a small script that can be used to build NewNode inside of a Docker container... except that the build current fails due to submodule breakage. Once it's fixed, I could take a stab at getting the build to finish the job and allow the resulting binary to be run inside the container. A proper CI setup would be the next step, but running this script as a cron job would start to detect failures caused by bit rot like this.

To use this script, first install `docker.io` on your host, then run `docker/build.sh` and watch it go.