### PR TITLE
fix typo for ipv6 assert

### DIFF
--- a/client.c
+++ b/client.c
@@ -57,7 +57,7 @@ typedef struct {
     in6_addr ip;
     port_t port;
 } PACKED packed_ipv6;
-static_assert(sizeof(packed_ipv4) == 6, "packed_ipv6 should be 18 bytes");
+static_assert(sizeof(packed_ipv6) == 18, "packed_ipv6 should be 18 bytes");
 
 typedef struct {
     sockaddr_storage addr;


### PR DESCRIPTION
noticed a copy-paste bug in ipv4 /ipv6 asserts
done a smoke test on linux/amd64, need additionally check ios/android on aarch64
