### PR TITLE
iOS: remove wormhole message data forcecast

### DIFF
--- a/ios/vpn/NewNode VPN/ViewController.swift
+++ b/ios/vpn/NewNode VPN/ViewController.swift
@@ -57,8 +57,9 @@ class ViewController: UIViewController {
         monitor.start(queue: .main)
 
         wormhole.listenForMessage(withIdentifier: "DisplayStats", listener: { (message) -> Void in
-            let o = message as! NSDictionary?
-            self.updateStatistics(direct: o?["direct_bytes"] as! UInt64, peer: o?["peers_bytes"] as! UInt64)
+            if let o = message as? NSDictionary, let direct = o["direct_bytes"] as? UInt64, let peer = o["peers_bytes"] as? UInt64 {
+                self.updateStatistics(direct: direct, peer: peer)
+            }
         })
 
         NotificationCenter.default.addObserver(self, selector:#selector(foreground), name:


### PR DESCRIPTION
Since the wormhole uses [__nullable id](https://github.com/mutualmobile/MMWormhole/blob/1405cb1dd7b07f1023bb81e445002bcc5e7ece56/Source/MMWormhole.m#L225) as listener's callback arg type it does not guarantee that you'll receive a dictionary.
So it would be much safe to unwrap value to the expected dictionary type before reading any values from it.