### PR TITLE
iOS: extract configuration into a separate namespace

### DIFF
--- a/ios/vpn/NewNode VPN/ViewController.swift
+++ b/ios/vpn/NewNode VPN/ViewController.swift
@@ -12,7 +12,16 @@ import Network
 import NetworkExtension
 
 
-class ViewController: UIViewController {
+private extension String {
+    static let applicationGroupIdentifier = "group.com.newnode.vpn"
+    static let wormholeStatisticMessageIdentifier = "DisplayStats"
+    
+    static let tunnelBundleIdentifier = "com.newnode.vpn.tunnel"
+    static let tunnelServerAddress = "NewNode"
+    static let tunnelLocalizedDescription = "NewNode"
+}
+
+final class ViewController: UIViewController {
     
     @IBOutlet var gradient: GradientView!
     @IBOutlet weak var powerButton: UIButton!
@@ -26,7 +35,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var logo: UIImageView!
     @IBOutlet var statTexts: [UILabel]!
     let monitor = NWPathMonitor()
-    let wormhole = MMWormhole(applicationGroupIdentifier: "group.com.newnode.vpn", optionalDirectory: nil)
+    let wormhole = MMWormhole(applicationGroupIdentifier: .applicationGroupIdentifier, optionalDirectory: nil)
     
     var toggleState: Bool {
         get {
@@ -56,7 +65,7 @@ class ViewController: UIViewController {
         }
         monitor.start(queue: .main)
 
-        wormhole.listenForMessage(withIdentifier: "DisplayStats", listener: { (message) -> Void in
+        wormhole.listenForMessage(withIdentifier: .wormholeStatisticMessageIdentifier, listener: { (message) -> Void in
             if let o = message as? NSDictionary, let direct = o["direct_bytes"] as? UInt64, let peer = o["peers_bytes"] as? UInt64 {
                 self.updateStatistics(direct: direct, peer: peer)
             }
@@ -178,11 +187,11 @@ class ViewController: UIViewController {
             if managers.count == 0 {
                 let manager = NETunnelProviderManager()
                 let providerProtocol = NETunnelProviderProtocol()
-                providerProtocol.providerBundleIdentifier = "com.newnode.vpn.tunnel"
-                providerProtocol.serverAddress = "NewNode"
+                providerProtocol.providerBundleIdentifier = .tunnelBundleIdentifier
+                providerProtocol.serverAddress = .tunnelServerAddress
                 manager.protocolConfiguration = providerProtocol
                 manager.isEnabled = true
-                manager.localizedDescription = "NewNode"
+                manager.localizedDescription = .tunnelLocalizedDescription
                 
                 manager.saveToPreferences(completionHandler: { (error: Error?) in
                     os_log("saveToPreferences %@", error?.localizedDescription ?? "")

--- a/ios/vpn/Tunnel/PacketTunnelProvider.swift
+++ b/ios/vpn/Tunnel/PacketTunnelProvider.swift
@@ -9,17 +9,25 @@
 import NetworkExtension
 import os.log
 
-enum NewNodeError: Error {
+private enum NewNodeError: Error {
     case initializationError
 }
 
-class PacketTunnelProvider: NEPacketTunnelProvider {
+private extension String {
+    static let applicationGroupIdentifier = "group.com.newnode.vpn"
+    static let wormholeStatisticMessageIdentifier = "DisplayStats"
+}
+
+private extension Notification.Name {
+    static let displayStatistic = Notification.Name("DisplayStats")
+}
+
+final class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         super.startTunnel(options: options, completionHandler: completionHandler)
 
-        NotificationCenter.default.addObserver(self, selector:#selector(displayStats), name:
-                                                Notification.Name("DisplayStats"), object: nil)
+        NotificationCenter.default.addObserver(self, selector:#selector(displayStats), name: .displayStatistic, object: nil)
 
         let cachesPath = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).last!
         chdir(cachesPath)
@@ -65,8 +73,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     @objc func displayStats(notification: NSNotification) {
         let o = notification.userInfo
-        let wormhole = MMWormhole(applicationGroupIdentifier: "group.com.newnode.vpn", optionalDirectory: nil)
-        wormhole.passMessageObject(o as NSDictionary?, identifier: "DisplayStats")
+        let wormhole = MMWormhole(applicationGroupIdentifier: .applicationGroupIdentifier, optionalDirectory: nil)
+        wormhole.passMessageObject(o as NSDictionary?, identifier: .wormholeStatisticMessageIdentifier)
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {


### PR DESCRIPTION
The configuration is very important part of every app and the good practice is to have it more specific declarative way